### PR TITLE
Adjustments to make it executable on Mac

### DIFF
--- a/makefile
+++ b/makefile
@@ -35,11 +35,11 @@ simplebwt64: simplebwt.c gsa/gsacak64.o
 cnewscan.x: newscan.cpp malloc_count.o utils.o
 	$(CXX) $(CXX_FLAGS) -DGZSTREAM -o $@ $^ -lgzstream -lz -ldl -DNOTHREADS
 
-newscanNT.x: newscan.cpp malloc_count.o utils.o
-	$(CXX) $(CXX_FLAGS) -o $@ $^ -lz -ldl -DNOTHREADS
+newscanNT.x: newscan.cpp utils.o
+	$(CXX) $(CXX_FLAGS) -o $@ newscan.cpp utils.o -lz -ldl -DNOTHREADS
 
-newscan.x: newscan.cpp newscan.hpp malloc_count.o utils.o xerrors.o 
-	$(CXX) $(CXX_FLAGS) -o $@ newscan.cpp malloc_count.o utils.o xerrors.o -ldl -lz -pthread
+newscan.x: newscan.cpp newscan.hpp utils.o xerrors.o 
+	$(CXX) $(CXX_FLAGS) -o $@ newscan.cpp utils.o xerrors.o -ldl -lz -pthread
 
 pscan.x: pscan.cpp pscan.hpp malloc_count.o utils.o xerrors.o 
 	$(CXX) $(CXX_FLAGS) -o $@ pscan.cpp malloc_count.o utils.o xerrors.o -ldl -pthread

--- a/newscan.cpp
+++ b/newscan.cpp
@@ -455,7 +455,7 @@ void print_help(char** argv, Args &args) {
 void parseArgs( int argc, char** argv, Args& arg ) {
    int c;
    extern char *optarg;
-   extern int optind;
+   //extern int optind;
 
   puts("==== Command line:");
   for(int i=0;i<argc;i++)
@@ -489,14 +489,16 @@ void parseArgs( int argc, char** argv, Args& arg ) {
         exit(1);
       }
    }
+
    // the only input parameter is the file name
-   if (argc == optind+1) {
-     arg.inputFileName.assign( argv[optind] );
-   }
-   else {
+   if (argc == 1) {
       cout << "Invalid number of arguments" << endl;
       print_help(argv,arg);
    }
+   else {
+      arg.inputFileName.assign(argv[1]);
+   }
+
    // check algorithm parameters
    if(arg.w <4) {
      cout << "Windows size must be at least 4\n";


### PR DESCRIPTION
- changed the logic to determine if no parameters were provided on command-line
- removed the linking of `malloc_count.o` in newscan/newscanNT.x executables since it lead to crashes.